### PR TITLE
Navbar org icon hide change

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,6 +21,9 @@ import API from "./utils/API";
 
 function App() {
 
+   // set current user
+   const [currentUser, setCurrentUser] = useState({})
+
   // Set login status
   const [loggedIn, setloggedIn] = useState({ loggedIn: false });
 
@@ -29,7 +32,7 @@ function App() {
     API.logout()
       .then(response => {
         console.log("logout API: ", response.data);
-          setloggedIn({ loggedIn: false });
+        setloggedIn({ loggedIn: false });
       })
       .catch(error => {
         console.log("check login error", error);
@@ -56,11 +59,27 @@ function App() {
   const { loggedIn: logStatus } = loggedIn;
   //console.log("App.js: ", logStatus);
 
+  // Call when components have loaded
+  useEffect(() => {
+    getCurrentUser();
+  }, [])
+
+  // Set current User State
+  function getCurrentUser() {
+    API.getCurrentUser()
+      .then(res => {
+        console.log("APP.js CURRENT USER", res.data);
+        setCurrentUser(res.data);
+      }
+      )
+  }
+
   return (
     <Router>
       <div data-component="DivInRouter">
         <Wrapper data-component="Wrapper"
           handleLogout={handleLogout}
+          currentUser={currentUser}
           loggedInStatus={loggedIn}
         >
           <Switch>

--- a/client/src/components/Navbar/index.js
+++ b/client/src/components/Navbar/index.js
@@ -5,6 +5,7 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
 import { useMediaQuery } from 'react-responsive';
+import "./style.css";
 
 /* -------------------------------------------------------------------------- */
 /*                              Define Component                              */
@@ -30,6 +31,26 @@ const Default = ({ children }) => {
 function Navbar(props) {
 
     const { loggedIn } = props.loggedInStatus;
+
+    function checkRole() {
+        if (props.currentUser.role === "Admin" || props.currentUser.is_manager) {
+            return (
+                <li className=" nav-item my-2 text-center">
+                    <NavLink to="/org" className="nav-link ps-2">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" className="bi bi-diagram-3-fill" viewBox="0 0 16 16">
+                            <path fillRule="evenodd" d="M6 3.5A1.5 1.5 0 0 1 7.5 2h1A1.5 1.5 0 0 1 10 3.5v1A1.5 1.5 0 0 1 8.5 6v1H14a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0v-1A.5.5 0 0 1 2 7h5.5V6A1.5 1.5 0 0 1 6 4.5v-1zm-6 8A1.5 1.5 0 0 1 1.5 10h1A1.5 1.5 0 0 1 4 11.5v1A1.5 1.5 0 0 1 2.5 14h-1A1.5 1.5 0 0 1 0 12.5v-1zm6 0A1.5 1.5 0 0 1 7.5 10h1a1.5 1.5 0 0 1 1.5 1.5v1A1.5 1.5 0 0 1 8.5 14h-1A1.5 1.5 0 0 1 6 12.5v-1zm6 0a1.5 1.5 0 0 1 1.5-1.5h1a1.5 1.5 0 0 1 1.5 1.5v1a1.5 1.5 0 0 1-1.5 1.5h-1a1.5 1.5 0 0 1-1.5-1.5v-1z" />
+                        </svg>
+                        <div>
+                            Org
+                </div>
+                    </NavLink>
+                </li>
+            )
+        }
+        else {
+            return;
+        }
+    };
 
     return (
         <>
@@ -80,7 +101,8 @@ function Navbar(props) {
                                             </div>
                                             </NavLink>
                                         </li>
-                                        <li className=" nav-item my-2 text-center">
+                                        {checkRole()}
+                                        {/* <li className=" nav-item my-2 text-center">
                                             <NavLink to="/org" className="nav-link ps-2">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" className="bi bi-diagram-3-fill" viewBox="0 0 16 16">
                                                     <path fillRule="evenodd" d="M6 3.5A1.5 1.5 0 0 1 7.5 2h1A1.5 1.5 0 0 1 10 3.5v1A1.5 1.5 0 0 1 8.5 6v1H14a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0v-1A.5.5 0 0 1 2 7h5.5V6A1.5 1.5 0 0 1 6 4.5v-1zm-6 8A1.5 1.5 0 0 1 1.5 10h1A1.5 1.5 0 0 1 4 11.5v1A1.5 1.5 0 0 1 2.5 14h-1A1.5 1.5 0 0 1 0 12.5v-1zm6 0A1.5 1.5 0 0 1 7.5 10h1a1.5 1.5 0 0 1 1.5 1.5v1A1.5 1.5 0 0 1 8.5 14h-1A1.5 1.5 0 0 1 6 12.5v-1zm6 0a1.5 1.5 0 0 1 1.5-1.5h1a1.5 1.5 0 0 1 1.5 1.5v1a1.5 1.5 0 0 1-1.5 1.5h-1a1.5 1.5 0 0 1-1.5-1.5v-1z" />
@@ -89,7 +111,7 @@ function Navbar(props) {
                                                     Org
                                             </div>
                                             </NavLink>
-                                        </li>
+                                        </li> */}
                                         {/* <li className=" nav-item my-2 text-cente mr-4">
                                             <NavLink to="/team" className="nav-link ps-2">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" className="bi bi-people-fill" viewBox="0 0 16 16">
@@ -179,7 +201,8 @@ function Navbar(props) {
                                         </div>
                                             </NavLink>
                                         </li>
-                                        <li className=" nav-item my-2 text-center">
+                                        {checkRole()}
+                                        {/* <li className=" nav-item my-2 text-center">
                                             <NavLink to="/org" className="nav-link ps-2">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" className="bi bi-diagram-3-fill" viewBox="0 0 16 16">
                                                     <path fillRule="evenodd" d="M6 3.5A1.5 1.5 0 0 1 7.5 2h1A1.5 1.5 0 0 1 10 3.5v1A1.5 1.5 0 0 1 8.5 6v1H14a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0v-1A.5.5 0 0 1 2 7h5.5V6A1.5 1.5 0 0 1 6 4.5v-1zm-6 8A1.5 1.5 0 0 1 1.5 10h1A1.5 1.5 0 0 1 4 11.5v1A1.5 1.5 0 0 1 2.5 14h-1A1.5 1.5 0 0 1 0 12.5v-1zm6 0A1.5 1.5 0 0 1 7.5 10h1a1.5 1.5 0 0 1 1.5 1.5v1A1.5 1.5 0 0 1 8.5 14h-1A1.5 1.5 0 0 1 6 12.5v-1zm6 0a1.5 1.5 0 0 1 1.5-1.5h1a1.5 1.5 0 0 1 1.5 1.5v1a1.5 1.5 0 0 1-1.5 1.5h-1a1.5 1.5 0 0 1-1.5-1.5v-1z" />
@@ -188,7 +211,7 @@ function Navbar(props) {
                                                     Org
                                             </div>
                                             </NavLink>
-                                        </li>
+                                        </li> */}
                                         {/* <li className=" nav-item my-2 text-center">
                                             <NavLink to="/team" className="nav-link ps-2">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" className="bi bi-people-fill" viewBox="0 0 16 16">
@@ -228,6 +251,19 @@ function Navbar(props) {
                             </ul>
                         </div>
                     </div>
+                        {!loggedIn ?
+                            <>
+                                <div>
+                                    {/* <p className="pt-5 logStatusInfo text-center text-white">Logged Out</p> */}
+                                </div> </> :
+                            <>
+                                <div>
+                                    <p className="pt-5 logStatusInfo text-center text-white">
+                                        Logged In As: {props.currentUser.first_name} {props.currentUser.last_name}
+                                    </p>
+                                </div>
+                            </>
+                        }
                 </nav>
             </Default>
         </>

--- a/client/src/components/Navbar/style.css
+++ b/client/src/components/Navbar/style.css
@@ -1,0 +1,8 @@
+.logStatusInfo {
+    font-family: 'Times New Roman', Times, serif;
+    font-size: small;
+    position:absolute;
+    left:0;
+    bottom:0;
+    right:0;
+}

--- a/client/src/components/Wrapper/index.js
+++ b/client/src/components/Wrapper/index.js
@@ -18,6 +18,7 @@ function Wrapper(props) {
 
     const { loggedIn } = props.loggedInStatus;
     const tempLine = `Logged In: ` + loggedIn;
+    console.log("Wrapper props: ", props);
     return (
         <main className="wrapper divvy-bg" data-component="Wrapper">
             <Row>
@@ -25,6 +26,7 @@ function Wrapper(props) {
                     <div className="text-warning text-center fw-bold fst-italic fs-1 mt-2 divvy-font-logo">Divvy</div>
                     <Nav
                         loggedInStatus={props.loggedInStatus}
+                        currentUser={props.currentUser}
                         handleLogout={props.handleLogout}>
                     </Nav>
                 </Col>


### PR DESCRIPTION
- Changed logic so that the Org Icon on the Navbar is only there for Admin or Managers. For all other users it will not be shown.
- Added a quick div on the Navbar to show which user is logged in. Open to changing it to look better or even contain more information if we want (could include team name / org name as well)